### PR TITLE
Repository View for MockModels and MockDatasets

### DIFF
--- a/app/[owner]/[repo]/page.tsx
+++ b/app/[owner]/[repo]/page.tsx
@@ -1,65 +1,82 @@
-// app/[owner]/repo/[repo].tsx
 "use client";
 
+import { useEffect, useState } from "react";
 import Layout from "@/app/components/layout/Layout";
-import { FilesAndVersions } from "@/app/components/repository/FilesAndVersions";
 import { ModelCard } from "@/app/components/repository/ModelCard";
 import { RepoHeader } from "@/app/components/repository/RepoHeader";
 import { Settings } from "@/app/components/repository/Settings";
-import { MOCK_REPO_DATA } from "@/app/data/repos";
-import { RepoTab } from "@/app/utils/type";
+import { FilesAndVersions } from "@/app/components/repository/FilesAndVersions";
+import { mockModels } from "@/app/data/models";
+import { mockDatasets } from "@/app/data/datasets";
+import { RepoTab, Model, Dataset } from "@/app/utils/type";
 import { useParams } from "next/navigation";
-import { useState } from "react";
 
 export default function RepositoryPage() {
   const [activeTab, setActiveTab] = useState<RepoTab>("model-card");
+  const [repoData, setRepoData] = useState<Model | Dataset | null>(null);
   const params = useParams();
   const { owner, repo } = params;
-  console.log("owner: ", owner);
-  console.log("repo: ", repo);
 
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case "model-card":
-        return <ModelCard />;
-      case "files":
-        return (
-          <FilesAndVersions
-            owner={MOCK_REPO_DATA.owner}
-            repo={MOCK_REPO_DATA.name}
-            defaultBranch="main"
-          />
-        );
-      case "community":
-        return (
-          <div className="p-4 text-gray-400">Community view coming soon...</div>
-        );
-      case "settings":
-        return (
-          <Settings
-            owner={""}
-            repo={""}
-            isPrivate={false}
-            hasDiscussions={false}
-          />
-        );
-    }
+  useEffect(() => {
+    // Find the repository in both models and datasets
+    const model = mockModels.find(
+      m => m.owner === owner && m.name === repo
+    );
+    const dataset = mockDatasets.find(
+      d => d.owner === owner && d.name === repo
+    );
+    
+    setRepoData(model || dataset || null);
+  }, [owner, repo]);
+
+  if (!repoData) {
+    return <div>Repository not found</div>;
+  }
+
+  const stats = {
+    likes: repoData.likes,
+    followers: 0,
+    downloads: repoData.downloads
   };
+
+  const tags = [
+    { type: "category", label: repoData.category },
+    { type: "task", label: repoData.task },
+    { type: "privacy", label: repoData.isPrivate ? "Private" : "Public" }
+  ];
 
   return (
     <Layout>
       <div className="min-h-screen flex flex-col">
         <div className="pt-16">
-          {" "}
-          {/* Added padding container */}
           <RepoHeader
-            {...MOCK_REPO_DATA}
+            owner={repoData.owner}
+            name={repoData.name}
+            stats={stats}
+            tags={[]}
             activeTab={activeTab}
             onTabChange={setActiveTab}
           />
         </div>
         <div className="flex-1 bg-gray-900">
-          <div className="max-w-7xl mx-auto">{renderTabContent()}</div>
+          <div className="max-w-7xl mx-auto">
+            {activeTab === "model-card" && <ModelCard item={repoData} />}
+            {activeTab === "files" && (
+              <FilesAndVersions
+                owner={repoData.owner}
+                repo={repoData.name}
+                defaultBranch="main"
+              />
+            )}
+            {activeTab === "settings" && (
+              <Settings
+                owner={repoData.owner}
+                repo={repoData.name}
+                isPrivate={repoData.isPrivate}
+                hasDiscussions={false}
+              />
+            )}
+          </div>
         </div>
       </div>
     </Layout>

--- a/app/components/dashboard/Dashboard.tsx
+++ b/app/components/dashboard/Dashboard.tsx
@@ -14,6 +14,8 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/hooks/useAuth";
 import LoadingSpinner from "../ui/LoadingSpinner";
 import { ProfileHeader } from "../profile/ProfileHeader";
+import { mockModels } from "@/app/data/models";
+import { mockDatasets } from "@/app/data/datasets";
 
 export default function Dashboard() {
   const [activeTab, setActiveTab] = useState("models");
@@ -59,6 +61,9 @@ export default function Dashboard() {
     );
   };
 
+  const userModels = mockModels.filter(model => model.owner === user.username);
+  const userDatasets = mockDatasets.filter(dataset => dataset.owner === user.username);
+
   return (
     <div className="min-h-screen pt-20 px-4">
       <div className="max-w-7xl mx-auto">
@@ -69,7 +74,7 @@ export default function Dashboard() {
           <div className="m-2">
             <span className="flex flex-row">
               <Microscope size={20} className="mr-2" />
-              Ai & ML Interests
+              AI & ML Interests
             </span>
             {renderStringList(user.interests)}
           </div>
@@ -124,9 +129,9 @@ export default function Dashboard() {
 
           {/* Content Grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {[1, 2, 3, 4].map((item) => (
+            {(activeTab === "models" ? userModels : userDatasets).map((item) => (
               <div
-                key={item}
+                key={item.id}
                 className="group relative bg-gray-950 rounded-lg border border-gray-800"
               >
                 <div className="absolute top-2 right-2 flex gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -153,21 +158,8 @@ export default function Dashboard() {
                 </div>
                 <Card
                   item={{
-                    id: item.toString(),
-                    name: `Sample ${activeTab === "models" ? "Model" : "Dataset"} ${item}`,
-                    description: "This is a sample description",
-                    category: "Computer Vision",
-                    likes: 100,
-                    owner: "user",
-                    avatar: "/placeholder-avatar.png",
-                    isPrivate: false,
-                    updatedAt: "2 days ago",
-                    downloads: 50,
-                    task: "Text Generation",
-                    ...(activeTab === "datasets" && {
-                      numRows: 1000,
-                      isViewable: true,
-                    }),
+                    ...item,
+                    avatar: user.avatar
                   }}
                   type={activeTab === "models" ? "model" : "dataset"}
                 />

--- a/app/components/repository/ModelCard.tsx
+++ b/app/components/repository/ModelCard.tsx
@@ -17,8 +17,7 @@ export function ModelCard({ item }: ModelCardProps) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const readmeKey = `${item.owner}/${item.name}`;
-    const readmeContent = mockReadme[readmeKey as keyof typeof mockReadme] || mockReadme.default;
+    const readmeContent= mockReadme.default;
 
     setTimeout(() => {
       setContent(readmeContent);

--- a/app/components/repository/ModelCard.tsx
+++ b/app/components/repository/ModelCard.tsx
@@ -5,140 +5,26 @@ import { useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Loader2 } from 'lucide-react';
-import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter';
-import oneDark from 'react-syntax-highlighter/dist/cjs/styles/prism/one-dark';
+import { Model, Dataset } from '@/app/utils/type';
+import { mockReadme } from '@/app/data/mockReadme';
 
-// If you want to optimize bundle size, you can also import only the languages you need:
-import typescript from 'react-syntax-highlighter/dist/cjs/languages/prism/typescript';
-import python from 'react-syntax-highlighter/dist/cjs/languages/prism/python';
-import bash from 'react-syntax-highlighter/dist/cjs/languages/prism/bash';
+interface ModelCardProps {
+  item: Model | Dataset;
+}
 
-// Register only the languages you need
-SyntaxHighlighter.registerLanguage('typescript', typescript);
-SyntaxHighlighter.registerLanguage('python', python);
-SyntaxHighlighter.registerLanguage('bash', bash);
-
-const MOCK_README = `# DeepThought 8B Llama
-
-This is a fine-tuned version of Llama-2 focused on deep reasoning and analysis.
-
-## Model Details
-
-- **Base Model:** Llama-2 8B
-- **Training Data:** Specialized reasoning datasets
-- **Use Cases:** Complex analysis, reasoning tasks
-
-## Usage
-
-\`\`\`python
-from transformers import AutoTokenizer, AutoModelForCausalLM
-
-model = AutoModelForCausalLM.from_pretrained("ruliad/deepthought-8b-llama")
-tokenizer = AutoTokenizer.from_pretrained("ruliad/deepthought-8b-llama")
-\`\`\`
-`;
-
-type MarkdownComponentProps = {
-  children: React.ReactNode;
-  inline?: boolean;
-  className?: string;
-} & React.HTMLAttributes<HTMLElement>;
-// type MarkdownComponentProps = {
-//     node?: any;
-//     inline?: boolean;
-//     className?: string;
-//     children: React.ReactNode;
-//   } & React.HTMLAttributes<HTMLElement>;
-
-const markdownComponents: Record<string, React.ComponentType<MarkdownComponentProps>> = {
-  h1: (props) => (
-    <h1 className="text-3xl font-bold mt-8 pb-2 mb-4 border-b border-gray-800 text-gray-200" {...props} />
-  ),
-  h2: (props) => (
-    <h2 className="text-2xl font-semibold mt-8 pb-2 mb-4 border-b border-gray-800 text-gray-200" {...props} />
-  ),
-  h3: (props) => (
-    <h3 className="text-xl font-semibold mt-6 mb-4 text-gray-200" {...props} />
-  ),
-  h4: (props) => (
-    <h4 className="text-lg font-semibold mt-6 mb-4 text-gray-200" {...props} />
-  ),
-  p: (props) => (
-    <p className="mb-4 text-gray-300 leading-relaxed" {...props} />
-  ),
-  a: (props) => (
-    <a className="text-blue-400 hover:text-blue-300 no-underline" {...props} />
-  ),
-  ul: (props) => (
-    <ul className="list-disc list-inside mb-4 space-y-2 text-gray-300" {...props} />
-  ),
-  ol: (props) => (
-    <ol className="list-decimal list-inside mb-4 space-y-2 text-gray-300" {...props} />
-  ),
-  li: (props) => (
-    <li className="text-gray-300" {...props} />
-  ),
-  blockquote: (props) => (
-    <blockquote className="border-l-4 border-gray-700 pl-4 my-4 text-gray-400 italic" {...props} />
-  ),
-  table: (props) => (
-    <div className="overflow-x-auto my-4">
-      <table className="min-w-full divide-y divide-gray-800 text-gray-300" {...props} />
-    </div>
-  ),
-  th: (props) => (
-    <th className="px-4 py-2 bg-gray-800/50 text-left text-sm font-semibold text-gray-200" {...props} />
-  ),
-  td: (props) => (
-    <td className="px-4 py-2 border-b border-gray-800 text-gray-300" {...props} />
-  ),
-  code: ({ inline, className, children, ...props }) => {
-    const match = /language-(\w+)/.exec(className || '');
-    return !inline && match ? (
-      <div className="my-4">
-        <SyntaxHighlighter
-          language={match[1]}
-          style={oneDark}
-          customStyle={{
-            margin: 0,
-            padding: '1rem',
-            borderRadius: '0.5rem',
-            background: 'rgba(31, 41, 55, 0.5)',
-          } as React.CSSProperties}
-          PreTag="div"
-          wrapLongLines
-        >
-          {String(children).replace(/\n$/, '')}
-        </SyntaxHighlighter>
-      </div>
-    ) : (
-      <code className="bg-gray-800/50 rounded px-1.5 py-0.5 text-sm font-mono text-gray-200" {...props}>
-        {children}
-      </code>
-    );
-  },
-  strong: (props) => (
-    <strong className="font-semibold text-gray-200" {...props} />
-  ),
-  hr: (props) => (
-    <hr className="my-8 border-gray-800" {...props} />
-  ),
-  img: (props) => (
-    <img className="rounded-lg max-w-full my-4" {...props} alt={ ''} />
-  ),
-};
-
-export function ModelCard() {
+export function ModelCard({ item }: ModelCardProps) {
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // Simulate API call to fetch README
+    const readmeKey = `${item.owner}/${item.name}`;
+    const readmeContent = mockReadme[readmeKey as keyof typeof mockReadme] || mockReadme.default;
+
     setTimeout(() => {
-      setContent(MOCK_README);
+      setContent(readmeContent);
       setLoading(false);
-    }, 1000);
-  }, []);
+    }, 500);
+  }, [item]);
 
   if (loading) {
     return (
@@ -147,12 +33,46 @@ export function ModelCard() {
       </div>
     );
   }
-  console.log(Node)
+
   return (
-    <article className="px-4 py-6 max-w-none">
+    <article className="prose prose-invert max-w-none px-4 py-6">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        components={markdownComponents}
+        components={{
+          code: ({className, children, ...props }) => {
+            const match = /language-(\w+)/.exec(className || '');
+            return match ? (
+              <div className="relative">
+                <pre className="bg-gray-800 rounded-lg p-4 overflow-x-auto">
+                  <code className={className} {...props}>
+                    {children}
+                  </code>
+                </pre>
+              </div>
+            ) : (
+              <code className="bg-gray-800 rounded px-1.5 py-0.5" {...props}>
+                {children}
+              </code>
+            );
+          },
+          h1: ({ children }) => (
+            <h1 className="text-2xl font-bold mb-4">{children}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="text-xl font-semibold mt-8 mb-4">{children}</h2>
+          ),
+          p: ({ children }) => (
+            <p className="text-gray-300 mb-4 leading-relaxed">{children}</p>
+          ),
+          ul: ({ children }) => (
+            <ul className="list-disc list-inside space-y-2 mb-4 text-gray-300">
+              {children}
+            </ul>
+          ),
+          li: ({ children }) => (
+            <li className="text-gray-300">{children}</li>
+          )
+        }}
       >
         {content || ''}
       </ReactMarkdown>

--- a/app/components/repository/Settings/index.tsx
+++ b/app/components/repository/Settings/index.tsx
@@ -111,7 +111,7 @@ export function Settings({ owner, repo, isPrivate: initialIsPrivate, hasDiscussi
               When enabled, users must share their contact information (email and username) and agree to your terms and conditions (if any) in order to access this model. You can download the list of users who have accepted and had access at any time.
             </p>
           </div>
-          <Button variant="outline">Enable Access requests</Button>
+          <Button variant="outline">Enable</Button>
         </div>
       </section>
 
@@ -127,7 +127,7 @@ export function Settings({ owner, repo, isPrivate: initialIsPrivate, hasDiscussi
               Discussions and Pull Requests are currently <span className="font-semibold">enabled</span> for this model. Members of the community can propose changes to this repository.
             </p>
           </div>
-          <Button variant="outline">Disable Discussions and PRs</Button>
+          <Button variant="outline">Disable</Button>
         </div>
       </section>
 
@@ -154,7 +154,7 @@ export function Settings({ owner, repo, isPrivate: initialIsPrivate, hasDiscussi
               Generate a Digital Object Identifier for this model. This action <span className="font-semibold">cannot</span> be undone. It will no longer be possible to delete, rename, transfer, or change the visibility to private.
             </p>
           </div>
-          <Button variant="outline">Generate DOI</Button>
+          <Button variant="outline">Generate</Button>
         </div>
       </section>
 

--- a/app/components/shared/Card.tsx
+++ b/app/components/shared/Card.tsx
@@ -1,6 +1,7 @@
 import { Model, Dataset } from '@/app/utils/type';
 import { DownloadIcon, HeartIcon, TableIcon } from 'lucide-react';
 import { useWindowSize } from '@/app/hooks/useWindowSize';
+import { useRouter } from 'next/navigation';
 
 type CardProps = {
   item: Model | Dataset;
@@ -12,9 +13,15 @@ export function Card({ item, type, showDescription = false }: CardProps) {
   const { width } = useWindowSize();
   const isMobile = width < 768;
   const isDataset = type === 'dataset';
+  const router = useRouter();
+  
+  const handleClick = () => {
+    router.push(`/${item.owner}/${item.name}`);
+  };
   
   return (
-    <div className="flex items-center justify-between py-4 border-b border-gray-800 hover:bg-gray-900/50 hover:border-blue-500 transition-all cursor-pointer px-4">
+    <div className="flex items-center justify-between py-4 border-b border-gray-800 hover:bg-gray-900/50 hover:border-blue-500 transition-all cursor-pointer px-4"
+    onClick={handleClick}>
       <div className="flex items-center gap-3 w-full">
         <img 
           src={item.avatar}

--- a/app/data/datasets.ts
+++ b/app/data/datasets.ts
@@ -79,5 +79,21 @@ export const mockDatasets: Dataset[] = [
       isViewable: true,
       task: "Text Generation"
 
-    }
+    },
+    {
+      id: '6',
+      name: 'OpenAlpaca',
+      owner: 'kitsunelynx2',
+      description: 'Multilingual sentiment analysis dataset covering 50 languages',
+      avatar: '/placeholder-avatar.png',
+      likes: 245,
+      isPrivate: false,
+      updatedAt: '5 days ago',
+      downloads: 8900,
+      category: 'NLP',
+      numRows: 2500000,
+      isViewable: true,
+      task: "Text Generation"
+
+    },
   ];

--- a/app/data/mockReadme.ts
+++ b/app/data/mockReadme.ts
@@ -1,23 +1,5 @@
 export const mockReadme = {
-  "default": `# Default Model
-
-## Description
-This is a default model description.
-
-## Details
-- **Owner:** defaultOwner
-- **Category:** General
-- **Task:** General Task
-- **Downloads:** 100
-- **Likes:** 10
-
-## Usage
-\`\`\`python
-# Example code for using this model
-print("Hello, World!")
-\`\`\`
-`,
-  "ruliad/deepthought": `# DeepThought 8B Llama
+  "default": `# Model Name
 
 This is a fine-tuned version of Llama-2 focused on deep reasoning and analysis.
 

--- a/app/data/mockReadme.ts
+++ b/app/data/mockReadme.ts
@@ -1,0 +1,39 @@
+export const mockReadme = {
+  "default": `# Default Model
+
+## Description
+This is a default model description.
+
+## Details
+- **Owner:** defaultOwner
+- **Category:** General
+- **Task:** General Task
+- **Downloads:** 100
+- **Likes:** 10
+
+## Usage
+\`\`\`python
+# Example code for using this model
+print("Hello, World!")
+\`\`\`
+`,
+  "ruliad/deepthought": `# DeepThought 8B Llama
+
+This is a fine-tuned version of Llama-2 focused on deep reasoning and analysis.
+
+## Model Details
+
+- **Base Model:** Llama-2 8B
+- **Training Data:** Specialized reasoning datasets
+- **Use Cases:** Complex analysis, reasoning tasks
+
+## Usage
+
+\`\`\`python
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained("ruliad/deepthought-8b-llama")
+tokenizer = AutoTokenizer.from_pretrained("ruliad/deepthought-8b-llama")
+\`\`\`
+`
+}; 

--- a/app/data/models.ts
+++ b/app/data/models.ts
@@ -55,5 +55,19 @@ export const mockModels: Model[] = [
       category: 'Multimodal',
       task: "Text Generation"
 
-    }
+    },
+    {
+      id: '5',
+      name: 'athena-v1.0-instruct',
+      owner: 'kitsunelynx2',
+      avatar: '/placeholder-avatar.png',
+      description: 'Advanced computer vision model for image recognition and scene understanding.',
+      isPrivate: false,
+      updatedAt: '2 days ago',
+      downloads: 1200,
+      likes: 328,
+      category: 'NLP',
+      task: "Text Generation"
+
+    },
   ];

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
+} 


### PR DESCRIPTION
Updated dashboard to display repositories of [owner] alone, by matching `user.username` with owner of the repository from mock Data.